### PR TITLE
Add gdal >= 3.2 compatibility

### DIFF
--- a/cartolinegen/generalize.py
+++ b/cartolinegen/generalize.py
@@ -20,8 +20,12 @@
  *                                                                         *
  ***************************************************************************/
 """
+try:
+    from osgeo import ogr
+except ImportError:
+    import ogr
 
-import ogr,sys,math,random,os
+import sys,math,random,os
 import numpy as np
 
 def zig_zag(a,b,c,d): #returns true if three segments form zig-zag


### PR DESCRIPTION
Reference : https://github.com/OSGeo/gdal/releases/tag/v3.2.0

> Python bindings: move implementation of scripts (except gdal2tiles) in osgeo.utils package to be reusable