### PR TITLE
Cast progress to int before passing to progressbar.setValue to avoid TypeError

### DIFF
--- a/cartolinegen/generalize.py
+++ b/cartolinegen/generalize.py
@@ -776,7 +776,7 @@ def Decide(g,closed,g_type,out_geom,alg_type,single_line):
 #--------------------------------------------------------------------------------------------------------------
 
 def progress_changed(progress):
-    progressbar.setValue(progress)     
+    progressbar.setValue(int(progress))
     
 def Generalize(scale,small_area,alg_type,inFile,outFile):   
 


### PR DESCRIPTION
Fixes the following error:
```python
TypeError: setValue(self, value: int): argument 1 has unexpected type 'float' 
Traceback (most recent call last):
  File "/home/zjosua/.local/share/QGIS/QGIS3/profiles/default/python/plugins/cartolinegen/cartolinegen.py", line 225, in run
    self.generalize(layer)
  File "/home/zjosua/.local/share/QGIS/QGIS3/profiles/default/python/plugins/cartolinegen/cartolinegen.py", line 327, in generalize
    generalize.Generalize(scale,area,alg_type,inFile,outFile)
  File "/home/zjosua/.local/share/QGIS/QGIS3/profiles/default/python/plugins/cartolinegen/generalize.py", line 825, in Generalize
    progress_changed(obj_index/num_of_objects*100)
  File "/home/zjosua/.local/share/QGIS/QGIS3/profiles/default/python/plugins/cartolinegen/generalize.py", line 779, in progress_changed
    progressbar.setValue(progress)
TypeError: setValue(self, value: int): argument 1 has unexpected type 'float'
```